### PR TITLE
Improve bus arrival timetable UI design

### DIFF
--- a/src/components/RouteTimeTable.js
+++ b/src/components/RouteTimeTable.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { formatArrivalTime } from "../util";
 import { Link } from "gatsby";
+import StopTimeLabel from "./StopTimeLabel";
 import { faChevronCircleRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { sortTripsByFrequentTimepoint } from "../util";
@@ -76,8 +76,8 @@ const RouteTimeTable = ({ trips, route, agency, service, direction }) => {
                 let value = indices.indexOf(j)
                 return (
                   <td key={`${t.id}-${i}-${j}`}
-                    className={`text-center text-sm border-r-2 timetable-entry ${formatArrivalTime(filtered[value].arrivalTime).indexOf("p") > -1 ? `font-semibold` : `font-base`}`}>
-                    {formatArrivalTime(filtered[value].arrivalTime).slice(0, -3)}
+                    className={`text-center text-sm border-r-2 timetable-entry`}>
+                    <StopTimeLabel arrivalTime={filtered[value].arrivalTime} />
                   </td>
                 )
               }
@@ -87,16 +87,14 @@ const RouteTimeTable = ({ trips, route, agency, service, direction }) => {
                     `
                     text-center text-sm border-r-2 border-opacity-25 border-dotted border-gray-700 z-0 timetable-entry tabular 
                     ${filtered.length === 0 && `bg-gray-100`} 
-                    ${formatArrivalTime(filtered[0].arrivalTime).indexOf("p") > -1 ? `font-semibold` : `font-base`}
                     ` :
                     `
                     text-center text-sm z-0 timetable-entry 
                     ${filtered.length === 0 && `bg-gray-100`} 
-                    ${formatArrivalTime(filtered[0].arrivalTime).indexOf("p") > -1 ? `font-semibold` : `font-base`}
                     `
                     }>
                   {filtered.length > 0 ?
-                    formatArrivalTime(filtered[0].arrivalTime).slice(0, -3) :
+                    <StopTimeLabel arrivalTime={filtered[0].arrivalTime} /> :
                     `-`
                   }
                 </td>

--- a/src/components/StopTimeLabel.js
+++ b/src/components/StopTimeLabel.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { formatArrivalTime } from "../util";
+
+const StopTimeLabel = ({ arrivalTime }) => {
+  return (
+    <time
+      className={formatArrivalTime(arrivalTime).indexOf("p") > -1 ? `font-semibold` : `font-base`}
+      dateTime={formatArrivalTime(arrivalTime, false, true)}>
+        {formatArrivalTime(arrivalTime).slice(0, -3)}
+    </time>
+  );
+};
+
+export default StopTimeLabel;

--- a/src/components/StopTimesHere.js
+++ b/src/components/StopTimesHere.js
@@ -74,9 +74,9 @@ const StopTimesHere = ({ times, routes, agency, serviceDays }) => {
                   here at:
                 </p>
 
-                <ul className="columns-4 sm:columns-5">
+                <ul className="columns-4 sm:columns-5 gap-0 border-l-2 border-dotted border-grey-700 text-center">
                   {timesByRoute[route.routeShortName][service].map((trip) => (
-                    <li>
+                    <li className="border-r-2 border-dotted border-grey-700">
                       <StopTimeLabel arrivalTime={trip.arrivalTime} />
                     </li>
                   ))}

--- a/src/components/StopTimesHere.js
+++ b/src/components/StopTimesHere.js
@@ -74,9 +74,11 @@ const StopTimesHere = ({ times, routes, agency, serviceDays }) => {
                   here at:
                 </p>
 
-                <ul className="grid grid-cols-4 grid-flow-cols">
+                <ul className="columns-4 sm:columns-5">
                   {timesByRoute[route.routeShortName][service].map((trip) => (
-                    <li className="inline">{formatArrivalTime(trip.arrivalTime, false)}</li>
+                    <li className={`${formatArrivalTime(trip.arrivalTime).indexOf("p") > -1 ? `font-semibold` : `font-base`}`}>
+                      {formatArrivalTime(trip.arrivalTime).slice(0, -3)}
+                    </li>
                   ))}
                 </ul>
               </AccordionContent>
@@ -89,5 +91,3 @@ const StopTimesHere = ({ times, routes, agency, serviceDays }) => {
 };
 
 export default StopTimesHere
-
-

--- a/src/components/StopTimesHere.js
+++ b/src/components/StopTimesHere.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import * as Accordion from "@radix-ui/react-accordion";
+import StopTimeLabel from "./StopTimeLabel";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import classNames from "classnames";
 import _ from "lodash";
@@ -7,7 +8,6 @@ import "../styles/accordion.css";
 import {
   createAgencyData,
   createRouteData,
-  formatArrivalTime,
   getServiceDays,
   getTripsByServiceDay,
 } from "../util";
@@ -76,8 +76,8 @@ const StopTimesHere = ({ times, routes, agency, serviceDays }) => {
 
                 <ul className="columns-4 sm:columns-5">
                   {timesByRoute[route.routeShortName][service].map((trip) => (
-                    <li className={`${formatArrivalTime(trip.arrivalTime).indexOf("p") > -1 ? `font-semibold` : `font-base`}`}>
-                      {formatArrivalTime(trip.arrivalTime).slice(0, -3)}
+                    <li>
+                      <StopTimeLabel arrivalTime={trip.arrivalTime} />
                     </li>
                   ))}
                 </ul>

--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,7 @@ import { head } from "lodash";
  * @param {boolean} showAp 
  * @returns 
  */
-export const formatArrivalTime = (time, showAp=true) => {
+export const formatArrivalTime = (time, showAp=true, twentyFourHr=false) => {
   let hour = time.hours;
   let minutes = time.minutes ? time.minutes.toString().padStart(2, "0") : "00";
   let ap = "am";
@@ -17,7 +17,7 @@ export const formatArrivalTime = (time, showAp=true) => {
     hour = time.hours;
     ap = "am";
   } else if (time.hours > 12 && time.hours < 24) {
-    hour = time.hours - 12;
+    if (!twentyFourHr) { hour = time.hours - 12; }
     ap = "pm";
   } else if (time.hours % 12 === 0) {
     hour = 12;
@@ -25,6 +25,10 @@ export const formatArrivalTime = (time, showAp=true) => {
   } else if (time.hours >= 24) {
     hour = time.hours - 24;
     ap = "am";
+  }
+  
+  if (twentyFourHr) {
+    hour = time.hours ? time.hours.toString().padStart(2, "0") : "00";
   }
 
   return `${hour}:${minutes}${showAp ? ` ${ap}` : ``}`;


### PR DESCRIPTION
Resolves #32. I changed the table direction, added bold for PM, and a border between columns.

I also switched to use a `<time>` element for `StopTimesHere` and `RouteTimeTable` for improved semantics. Because of poor screen reader support, there remains an accessibility gap in determining whether a stop time is AM or PM. In the future, we should specify this in the element text.