### PR TITLE
Bump Mapbox GL version to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "gatsby-source-sanity": "^7.4.2",
     "gatsby-transformer-sharp": "^4.4.0",
     "lodash": "^4.17.21",
-    "mapbox-gl": "^1.13.2",
+    "mapbox-gl": "^2.12.0",
     "postcss": "^8.4.5",
     "postgraphile-plugin-connection-filter": "^2.2.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
+    "react-map-gl": "^7.0.21",
     "react-portable-text": "^0.4.3",
     "tailwindcss": "^3.0.13"
   }

--- a/src/components/AgencyMap.js
+++ b/src/components/AgencyMap.js
@@ -1,58 +1,64 @@
 import bbox from "@turf/bbox";
-import { Map, NavigationControl } from "mapbox-gl";
+import MapboxGL from "mapbox-gl/dist/mapbox-gl";
+import Mapbox, { NavigationControl } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import React, { useEffect } from "react";
+import React, { useRef } from "react";
 import { navigate } from "gatsby";
 import mapboxStyle from "../styles/mapbox.json";
 
 const AgencyMap = ({ routesFc, agency }) => {
-
   const routeFeatureCollection = routesFc
+  
+  const map = useRef();
 
   let mapInitialBbox = bbox(routeFeatureCollection)
-
-  useEffect(() => {
-    const accessToken = process.env.MAPBOX_ACCESS_TOKEN;
-
-    let map = new Map({
-      container: "map",
-      style: mapboxStyle,
-      bounds: mapInitialBbox,
-      fitBoundsOptions: {
-        padding: 50,
-        maxZoom: 17,
-      },
-      interactive: true,
-      accessToken: accessToken,
-    });
-
-    map.addControl(new NavigationControl({ showCompass: false }));
-
-    map.on("load", () => {
-      map.resize();
-      if(routeFeatureCollection.features.length > 0) {
-        map.getSource("routes").setData(routeFeatureCollection);
-      }
-    });
-
-    map.on("click", "stops-points", (e) => {
-      let stop = map.queryRenderedFeatures(e.point, {
-        layers: ["stops-points"]
-      })[0];
-      
+  
+  if(routeFeatureCollection.features.length > 0) {
+    mapboxStyle.sources.routes.data = routeFeatureCollection;
+  }
+  
+  const handleClick = (e) => {
+    let stop = map.current.queryRenderedFeatures(e.point, {
+      layers: ["stops-points"]
+    })[0];
+    
+    if (stop) {
       navigate(`/${agency.slug.current}/stop/${stop.properties.stopCode}`)
-    });
-    
-    map.on("mouseover", "stops-points", () => {
-      map.getCanvas().style.cursor = "pointer";
-    });
-    
-    map.on("mouseleave", "stops-points", () => {
-      map.getCanvas().style.cursor = "";
-    });
-  }, []);
+    }
+  };
+  
+  const handleMouseEnter = () => {
+    map.current.getCanvas().style.cursor = "pointer";
+  };
+  
+  const handleMouseLeave = () => {
+    map.current.getCanvas().style.cursor = "";
+  };
+  
+  const initialViewState = {
+    bounds: mapInitialBbox,
+    fitBoundsOptions: {
+      padding: 50,
+      maxZoom: 17,
+    }
+  };
 
-  return <div id="map" style={{height: 500}}></div>;
+  return (
+    <div id="map" style={{height: 500}}>
+      <Mapbox
+        ref={map}
+        mapLib={MapboxGL}
+        mapboxAccessToken={process.env.MAPBOX_ACCESS_TOKEN}
+        mapStyle={mapboxStyle}
+        initialViewState={initialViewState}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        interactiveLayerIds={[ "stops-points" ]}>
+          <NavigationControl showCompass={false} />
+      </Mapbox>
+    </div>
+  );
 };
 
 export default AgencyMap;

--- a/src/components/RouteMap.js
+++ b/src/components/RouteMap.js
@@ -1,7 +1,8 @@
 import bbox from "@turf/bbox";
-import { Map, NavigationControl } from "mapbox-gl";
+import MapboxGL from "mapbox-gl/dist/mapbox-gl";
+import Mapbox, { NavigationControl } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import React, { useEffect } from "react";
+import React, { useRef } from "react";
 import { navigate } from "gatsby";
 import mapboxStyle from "../styles/mapbox.json";
 
@@ -11,60 +12,67 @@ const RouteMap = ({ routeFc, stopsFc, timepointsFc, agency }) => {
   const routeFeatureCollection = routeFc
   const stopsFeatureCollection = stopsFc
   const timepointsFeatureCollection = timepointsFc
+  
+  const map = useRef();
 
   let mapInitialBbox = routeFeatureCollection.features.length > 0 ?
     bbox(routeFeatureCollection) : bbox(stopsFeatureCollection)
 
   let stopProperty = ['smart', 'the-ride'].indexOf(agency.slug.current) > -1 ? 'stopId' : 'stopCode'
-
-  useEffect(() => {
-    const accessToken = process.env.MAPBOX_ACCESS_TOKEN;
-
-    let map = new Map({
-      container: "map",
-      style: mapboxStyle,
-      bounds: mapInitialBbox,
-      fitBoundsOptions: {
-        padding: 50,
-        maxZoom: 17,
-      },
-      interactive: true,
-      accessToken: accessToken,
-    });
-
-    map.addControl(new NavigationControl({ showCompass: false }));
-
-    map.on("load", () => {
-      map.resize();
-      if(routeFeatureCollection.features.length > 0) {
-        map.getSource("routes").setData(routeFeatureCollection);
-      }
-      if(stopsFeatureCollection.features.length > 0) {
-        map.getSource("stops").setData(stopsFeatureCollection)
-      }
-      if(timepointsFeatureCollection.features.length > 0) {
-        map.getSource("timepoints").setData(timepointsFeatureCollection)
-      }
-    });
-
-    map.on("click", "stops-points", (e) => {
-      let stop = map.queryRenderedFeatures(e.point, {
-        layers: ["stops-points"]
-      })[0];
-      
+  
+  console.log(mapboxStyle)
+  if(routeFeatureCollection.features.length > 0) {
+    mapboxStyle.sources.routes.data = routeFeatureCollection;
+  }
+  if(stopsFeatureCollection.features.length > 0) {
+    mapboxStyle.sources.stops.data = stopsFeatureCollection;
+  }
+  if(timepointsFeatureCollection.features.length > 0) {
+    mapboxStyle.sources.timepoints.data = timepointsFeatureCollection;
+  }
+  
+  const handleClick = (e) => {
+    let stop = map.current.queryRenderedFeatures(e.point, {
+      layers: ["stops-points"]
+    })[0];
+    
+    if (stop) {
       navigate(`/${agency.slug.current}/stop/${stop.properties[stopProperty]}`)
-    });
-    
-    map.on("mouseover", "stops-points", () => {
-      map.getCanvas().style.cursor = "pointer";
-    });
-    
-    map.on("mouseleave", "stops-points", () => {
-      map.getCanvas().style.cursor = "";
-    });
-  }, []);
-
-  return <div id="map" style={{height: 500}}></div>;
+    }
+  };
+  
+  const handleMouseEnter = () => {
+    map.current.getCanvas().style.cursor = "pointer";
+  };
+  
+  const handleMouseLeave = () => {
+    map.current.getCanvas().style.cursor = "";
+  };
+  
+  const initialViewState = {
+    bounds: mapInitialBbox,
+    fitBoundsOptions: {
+      padding: 50,
+      maxZoom: 17,
+    }
+  };
+  
+  return (
+    <div id="map" style={{height: 500}}>
+      <Mapbox
+        ref={map}
+        mapLib={MapboxGL}
+        mapboxAccessToken={process.env.MAPBOX_ACCESS_TOKEN}
+        mapStyle={mapboxStyle}
+        initialViewState={initialViewState}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        interactiveLayerIds={[ "stops-points" ]}>
+          <NavigationControl showCompass={false} />
+      </Mapbox>
+    </div>
+  );
 };
 
 export default RouteMap;

--- a/src/components/StopMap.js
+++ b/src/components/StopMap.js
@@ -1,43 +1,33 @@
 import bbox from "@turf/bbox";
-import { Map, NavigationControl } from "mapbox-gl";
+import MapboxGL from "mapbox-gl/dist/mapbox-gl";
+import Mapbox, { NavigationControl } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import React, { useEffect } from "react";
+import React from "react";
 import mapboxStyle from "../styles/mapbox.json";
 
 const StopMap = ({ stopFc }) => {
+  let stop = stopFc.features[0];
 
-  useEffect(() => {
-    const accessToken = process.env.MAPBOX_ACCESS_TOKEN;
-
-    let stop = stopFc.features[0]
-
-    let map = new Map({
-      container: "map",
-      style: mapboxStyle,
-      center: stop.geometry.coordinates,
-      zoom: 17.25,
-      interactive: true,
-      accessToken: accessToken,
-    });
-
-    map.addControl(new NavigationControl({ showCompass: false }));
-
-    map.on("load", () => {
-      map.resize();
-      if(stopFc.features.length > 0) {
-        map.getSource("stop").setData(stopFc);
-      }
-      // if(timepointsFeatureCollection.features.length > 0) {
-      //   map.getSource("timepoints").setData(timepointsFeatureCollection)
-      // }
-    });
-
-    map.on("click", (e) => {
-      const features = map.queryRenderedFeatures(e.point);
-    });
-  }, []);
-
-  return <div id="map" style={{height: 350}}></div>;
+  console.log(mapboxStyle);
+  mapboxStyle.sources.stop.data = stopFc;
+  
+  const initialViewState = {
+    longitude: stop.geometry.coordinates[0],
+    latitude: stop.geometry.coordinates[1],
+    zoom: 17.25
+  };
+  
+  return (
+    <div id="map" style={{height: 350}}>
+      <Mapbox
+        mapLib={MapboxGL}
+        mapboxAccessToken={process.env.MAPBOX_ACCESS_TOKEN}
+        mapStyle={mapboxStyle}
+        initialViewState={initialViewState}>
+          <NavigationControl showCompass={false} />
+      </Mapbox>
+    </div>
+  );
 };
 
 export default StopMap;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,7 +2084,7 @@
   resolved "https://registry.yarnpkg.com/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz#c72e8b6faae31d925d23a6db0379cc3fe0216fdd"
   integrity sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==
 
-"@mapbox/geojson-rewind@^0.5.0":
+"@mapbox/geojson-rewind@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
   integrity sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==
@@ -2092,35 +2092,30 @@
     get-stream "^6.0.1"
     minimist "^1.2.6"
 
-"@mapbox/geojson-types@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz#9aecf642cb00eab1080a57c4f949a65b4a5846d6"
-  integrity sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==
-
 "@mapbox/jsonlint-lines-primitives@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
   integrity sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==
 
-"@mapbox/mapbox-gl-supported@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz#f60b6a55a5d8e5ee908347d2ce4250b15103dc8e"
-  integrity sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==
+"@mapbox/mapbox-gl-supported@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz#c15367178d8bfe4765e6b47b542fe821ce259c7b"
+  integrity sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ==
 
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
   integrity sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==
 
-"@mapbox/tiny-sdf@^1.1.1":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz#424c620a96442b20402552be70a7f62a8407cc59"
-  integrity sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==
+"@mapbox/tiny-sdf@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz#cdba698d3d65087643130f9af43a2b622ce0b372"
+  integrity sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw==
 
-"@mapbox/unitbezier@^0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz#15651bd553a67b8581fb398810c98ad86a34524e"
-  integrity sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==
+"@mapbox/unitbezier@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz#d32deb66c7177e9e9dfc3bbd697083e2e657ff01"
+  integrity sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
 
 "@mapbox/vector-tile@^1.3.1":
   version "1.3.1"
@@ -2689,6 +2684,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
+"@types/geojson@*":
+  version "7946.0.10"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
+  integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
+
 "@types/get-port@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/get-port/-/get-port-3.2.0.tgz#f9e0a11443cc21336470185eae3dfba4495d29bc"
@@ -2787,6 +2787,13 @@
   version "4.14.178"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
   integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
+"@types/mapbox-gl@^2.6.0":
+  version "2.7.10"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.7.10.tgz#a3a32a366bad8966c0a40b78209ed430ba018ce1"
+  integrity sha512-nMVEcu9bAcenvx6oPWubQSPevsekByjOfKjlkr+8P91vawtkxTnopDoXXq1Qn/f4cg3zt0Z2W9DVsVsKRNXJTw==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/mdast@^3.0.0":
   version "3.0.10"
@@ -5352,7 +5359,7 @@ duplexify@^4.1.1:
     readable-stream "^3.1.1"
     stream-shift "^1.0.0"
 
-earcut@^2.2.2:
+earcut@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
   integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
@@ -7164,7 +7171,7 @@ github-slugger@^1.2.1:
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.4.0.tgz#206eb96cdb22ee56fdc53a28d5a302338463444e"
   integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
 
-gl-matrix@^3.2.1:
+gl-matrix@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.3.tgz#fc1191e8320009fd4d20e9339595c6041ddc22c9"
   integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
@@ -9084,34 +9091,32 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^1.18.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.13.2.tgz#76639c44f141f8dff71b7d8f1504f2aed11f7517"
-  integrity sha512-CPjtWygL+f7naL+sGHoC2JQR0DG7u+9ik6WdkjjVmz2uy0kBC2l+aKfdi3ZzUR7VKSQJ6Mc/CeCN+6iVNah+ww==
+mapbox-gl@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-2.12.0.tgz#e9df28e72adc2f5b5999007e836df72c2f189e10"
+  integrity sha512-T60fbDV1ULikrhwPdRbpeQOF02+Nhv7QgJ4uGfKWybkoH+DdCxNWTmT7OFiKR0uz9ed98TAodYiHZQAQtFdwwQ==
   dependencies:
-    "@mapbox/geojson-rewind" "^0.5.0"
-    "@mapbox/geojson-types" "^1.0.2"
+    "@mapbox/geojson-rewind" "^0.5.2"
     "@mapbox/jsonlint-lines-primitives" "^2.0.2"
-    "@mapbox/mapbox-gl-supported" "^1.5.0"
+    "@mapbox/mapbox-gl-supported" "^2.0.1"
     "@mapbox/point-geometry" "^0.1.0"
-    "@mapbox/tiny-sdf" "^1.1.1"
-    "@mapbox/unitbezier" "^0.0.0"
+    "@mapbox/tiny-sdf" "^2.0.5"
+    "@mapbox/unitbezier" "^0.0.1"
     "@mapbox/vector-tile" "^1.3.1"
     "@mapbox/whoots-js" "^3.1.0"
     csscolorparser "~1.0.3"
-    earcut "^2.2.2"
+    earcut "^2.2.4"
     geojson-vt "^3.2.1"
-    gl-matrix "^3.2.1"
+    gl-matrix "^3.4.3"
     grid-index "^1.1.0"
-    minimist "^1.2.5"
     murmurhash-js "^1.0.0"
     pbf "^3.2.1"
-    potpack "^1.0.1"
+    potpack "^2.0.0"
     quickselect "^2.0.0"
     rw "^1.3.3"
-    supercluster "^7.1.0"
+    supercluster "^7.1.5"
     tinyqueue "^2.0.3"
-    vt-pbf "^3.1.1"
+    vt-pbf "^3.1.3"
 
 markdown-escapes@^1.0.0:
   version "1.0.4"
@@ -10817,10 +10822,10 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-potpack@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/potpack/-/potpack-1.0.2.tgz#23b99e64eb74f5741ffe7656b5b5c4ddce8dfc14"
-  integrity sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==
+potpack@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/potpack/-/potpack-2.0.0.tgz#61f4dd2dc4b3d5e996e3698c0ec9426d0e169104"
+  integrity sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==
 
 potrace@^2.1.8:
   version "2.1.8"
@@ -11208,6 +11213,13 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-map-gl@^7.0.21:
+  version "7.0.21"
+  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-7.0.21.tgz#264b89b31dbd8f020dbddf49f89f282dfcedcc8b"
+  integrity sha512-Cmokphv6VHfRJsHVjCtn7nw5mf8rl89CHdvPSaif0OWZZqe+pxM2/5hEr4EvPWeTokRPCo1XTrBpGbShkEuktQ==
+  dependencies:
+    "@types/mapbox-gl" "^2.6.0"
 
 react-portable-text@^0.4.3:
   version "0.4.3"
@@ -12546,7 +12558,7 @@ sudo-prompt@^8.2.0:
   resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-8.2.5.tgz#cc5ef3769a134bb94b24a631cc09628d4d53603e"
   integrity sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==
 
-supercluster@^7.1.0:
+supercluster@^7.1.5:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.5.tgz#65a6ce4a037a972767740614c19051b64b8be5a3"
   integrity sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==
@@ -13500,7 +13512,7 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-vt-pbf@^3.1.1:
+vt-pbf@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.1.3.tgz#68fd150756465e2edae1cc5c048e063916dcfaac"
   integrity sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==


### PR DESCRIPTION
I've also refactored to use `react-map-gl`, a React wrapper for Mapbox GL supported by Uber, Mapbox, and others. The API is modeled after `mapbox-gl-js`, so it should still feel familiar.