### PR TITLE
Added agency fare information

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -286,6 +286,10 @@ export const createAgencyData = (gtfsAgency, sanityAgency) => {
   gtfsAgency.name = sanityAgency.name
   gtfsAgency.color = sanityAgency.color
   gtfsAgency.textColor = sanityAgency.textColor
+  gtfsAgency.fareAttributes = sanityAgency.fareAttributes?.length ?
+    sanityAgency.fareAttributes : gtfsAgency.fareAttributes
+  gtfsAgency.fareContent = sanityAgency.fareContent
+  
   return gtfsAgency
 
 }

--- a/studio/schemas/agency.js
+++ b/studio/schemas/agency.js
@@ -54,6 +54,19 @@ export default {
       title: "Block content",
       description: "Extended information about this agency",
       type: "blockContent"
+    },
+    {
+      name: "fareAttributes",
+      title: "Fares",
+      description: "Details about each type of fare offered",
+      type: "array",
+      of: [{ type: "fareAttribute" }],
+    },
+    {
+      name: "fareContent",
+      title: "Fare content",
+      description: "Extended information about this agency's fare rules",
+      type: "blockContent"
     }
   ]
 }

--- a/studio/schemas/fareAttribute.js
+++ b/studio/schemas/fareAttribute.js
@@ -1,0 +1,42 @@
+export default {
+  name: "fareAttribute",
+  title: "Fare type details",
+  type: "document",
+  fields: [
+    {
+      name: "price",
+      title: "Price",
+      description: "The regular cost of the fare",
+      type: "number",
+    },
+    {
+      name: "currencyType",
+      title: "Currency code",
+      description: "Type of currency used to pay the fare",
+      type: "string",
+    },
+    {
+      name: "transfers",
+      title: "Number of transfers",
+      description: "The number of times a transfer ticket can be used before it's exhausted. Leave blank for unlimited uses",
+      type: "number"
+    },
+    {
+      name: "transferDuration",
+      title: "Transfer duration",
+      description: "The time in seconds that a transfer ticket is valid for. Set to 0 for unlimited duration",
+      type: "number"
+    }
+  ],
+  preview: {
+    select: {
+      price: "price",
+      currencyType: "currencyType",
+    },
+    prepare({ price, currencyType }) {
+      return {
+        title: `${price} ${currencyType}`,
+      };
+    },
+  },
+};

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -8,6 +8,7 @@ import destination from './destination'
 import destinationRoute from "./destinationRoute";
 import indexPage from "./indexPage";
 import extRouteDirection from "./extRouteDirection";
+import fareAttribute from "./fareAttribute";
 import journeyPart from "./journeyPart";
 import journey from "./journey";
 import journeyPartDestTime from "./journeyPartDestTime";
@@ -27,5 +28,6 @@ export default [
   journey,
   journeyPart,
   journeyPartDestTime,
-  extRouteDirection
+  extRouteDirection,
+  fareAttribute
 ];


### PR DESCRIPTION
Resolves #13. You can override the GTFS data via a new Sanity schema, and there is also a field for extended text content.

Long term, we'll need to figure out how to automatically populate `fare_attributes.agency_id` in Postgres. It's an implied field for single-agency GTFS feeds, so that might be why it's missing.